### PR TITLE
Cscwm65072.main.containerz service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # xr-appmgr-build
 Scripts to build RPMs for use with the XR appmgr.
 
-# Building an RPM
+# Building an RPM to be installed using appmgr cli workflow
+(Scriplets support will be deprecated soon using this install method)
 
 Create a `build.yaml` file and add entries for your app
 ```
@@ -22,26 +23,6 @@ packages:
       dir: examples/alpine/data #Not editable
   copy_hostname: true # Copy router hostname into config dir (only useful for eXR platforms)
   copy_ems_cert: true # Copy router ems certificate into config dir
-```
-
-# Building a TPA  RPM
-Create a `build.yaml` file and add entries for your app
-```
-- name: "partner-alpine" # Prefix "owner-" or "partner-" for TPA apps (Prefix not editable)
-  release: "7.10.1" # This is the release since when the support for this rpm has started and should correspond to a file in release_configs dir (Not editable)
-  target-release: "7.10.1" # If present, this is the release for rpms to be installed, else above release is used. (Editable)
-  version: "3.14" #Editable
-  partner-name: "radware" # Needed only for Partner rpms (Editable)
-  sources:
-      name: alpine #This has to be same as tar.gz file name below
-      file: examples/alpine/alpine.tar.gz # File must have "tar.gz" extension (Editable)
-            # Tar file must be built with "--platform=linux/x86_64" option specified during docker build
-  config-dir:
-      name: alpine #This has to be same as config's parent directory name below
-      dir: examples/alpine/config #Not editable
-  data-dir:
-      name: alpine #This has to be same as data's parent directory name below
-      dir: examples/alpine/data #Not editable
 ```
 Build:
 `./appmgr_build -b examples/alpine/build.yaml`
@@ -70,7 +51,56 @@ You can uninstall the RPM with the following:
 appmgr package uninstall package alpine-0.1.0-eXR_7.3.1.x86_64
 ```
 
-# Building a process-script RPM
+
+# Building an RPM to be installed using XR install cli workflow
+(Scriplets are not supported using this install method)
+Create a `build.yaml` file and add entries for your app
+```
+- name: "partner-alpine" # Prefix "owner-" or "partner-" for TPA apps (Prefix not editable)
+  release: "7.10.1" # This is the release since when the support for this rpm has started and should correspond to a file in release_configs dir (Not editable)
+  target-release: "7.10.1" # If present, this is the release for rpms to be installed, else above release is used. (Editable)
+  version: "3.14" #Editable
+  partner-name: "radware" # Needed only for Partner rpms (Editable)
+  sources:
+      name: alpine #This has to be same as tar.gz file name below
+      file: examples/alpine/alpine.tar.gz # File must have "tar.gz" extension (Editable)
+            # Tar file must be built with "--platform=linux/x86_64" option specified during docker build
+  config-dir:
+      name: alpine #This has to be same as config's parent directory name below
+      dir: examples/alpine/config #Not editable
+  data-dir:
+      name: alpine #This has to be same as data's parent directory name below
+      dir: examples/alpine/data #Not editable
+```
+Build:
+`./appmgr_build -b examples/alpine/build.yaml`
+
+Once the RPM is built, create a directory on the router at /harddisk:/owner-alpine/, scp it to this path, and install.
+
+```
+scp RPMS/x86_64/alpine-0.1.0-eXR_7.3.1.x86_64.rpm <router>:/harddisk:/owner-alpine/
+```
+
+Note that if you specify `copy_ems_cert` you must install the RPM after gRPC is configured (see above). The post-install script requires the ems certificate to have been created at install time or the application will be unable to access it.
+"grpc no-tls config should not be used if copy_ems_cert option is specified"
+
+
+
+```
+ install source /harddisk:/owner-alpine/ all
+```
+
+Config:
+```
+appmgr application alpine activate type docker source alpine docker-run-opts "-v {app_install_root}/config/alpine-configs:/root/config"
+```
+
+You can uninstall the RPM with the following:
+```
+install package remove owner-alpine
+```
+
+# Building a process-script RPM to be installed using appmgr cli workflow
 Create a `build.yaml` file and add entries for your app
 ```
 - name: "pscript" #This should not be changed (Not editable)
@@ -139,6 +169,69 @@ We can optionally pass comma separated package name(s) in build command with -p 
 If we don't pass -p option, it will build for all the packages in build.yaml file.
 ```
 
+# Building a owner-process-script RPM to be installed using XR cli workflow
+Create a `build.yaml` file and add entries for your app
+```
+- name: "owner-pscript" #This should not be changed (Not editable)
+  release: "24.1.1" # This is the release since when the support for this rpm has started and should correspond to a file in release_configs dir (Not editable)
+  target-release: "24.1.1" # If present, RPM name will have this target-release name, else will have above release name (Editable)
+  version: "0.1.0" # Application semantic version (Editable)
+  sources:
+    - name: pscript # Update this with the rpm name to be built (Editable)
+      dir: examples/pscript # All the files in this direcotory to be copied to process-script rpm (Editable)
+
+```
+Build:
+`./appmgr_build -b examples/alpine/build.yaml`
+
+Once the RPM is built, scp it to the router, and install.
+
+```
+scp RPMS/x86_64/owner-pscript-0.1.0-24.1.1.x86_64.rpm <router>:/harddisk:/owner-pscript/
+```
+You can install the RPM with the following:
+(As it's not a docker container, no need to activate this rpm)
+```
+install source /harddisk:/owner-pscript/ all
+```
+
+You can uninstall the RPM with the following:
+```
+install package remove owner-alpine
+```
+The files in the rpm, will be copied to below location in the device
+```
+/opt/owner/ops-script-repo/exec/
+```
+
+You can get rpm details using below commands
+```
+rpm -qpl RPMS/x86_64/owner-pscript-0.1.0-24.1.1.x86_64.rpm
+warning: RPMS/x86_64/owner-pscript-0.1.0-24.1.1.x86_64.rpm: Header V4 DSA/SHA1 Signature, key ID 73f45f20: NOKEY
+/opt/owner/ops-script-repo/exec
+/opt/owner/ops-script-repo/exec/pscript
+/opt/owner/ops-script-repo/exec/pscript/.gitignore
+
+rpm -qpi RPMS/x86_64/owner-pscript-0.1.0-24.1.1.x86_64.rpm
+warning: owner-pscript-0.1.0-24.1.1.x86_64.rpm: Header V4 DSA/SHA1 Signature, key ID 530b8c02: NOKEY
+Name        : owner-pscript
+Version     : 0.1.0
+Release     : 24.1.1
+Architecture: x86_64
+Install Date: (not installed)
+Group       : 3rd party application
+Size        : 71
+License     : Copyright (c) 2020 Cisco Systems Inc. All rights reserved
+Signature   : DSA/SHA1, Mon 22 Jan 2024 06:28:24 PM IST, Key ID dc8ed574530b8c02
+Source RPM  : owner-pscript-0.1.0-24.1.1.src.rpm
+Build Date  : Mon 22 Jan 2024 06:28:24 PM IST
+Build Host  : 756440a098a2
+Relocations : /
+Packager    : cisco
+Summary     : owner-pscript 0.1.0 compiled for IOS-XR 24.1.1
+Description :
+This packages the artifacts required to run a 3rd party app
+```
 # Build and Setup instructions
 
 ## Setting up the build environment

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ appmgr package uninstall package alpine-0.1.0-eXR_7.3.1.x86_64
 ```
 
 
-# Building an RPM to be installed using XR install cli workflow
+# Building an RPM to be installed using XR install cli workflow(LNT platform only)
 (Scriplets are not supported using this install method)
 
 Create a `build.yaml` file and add entries for your app
@@ -72,7 +72,16 @@ Create a `build.yaml` file and add entries for your app
   data-dir:
       name: alpine #This has to be same as data's parent directory name below
       dir: examples/alpine/data #Not editable
+  service-dir: #The service file is only applicable to the RPMs which needs containerz workflow support.
+    - name: alpine #This has to be same as service's parent directory name below
+      dir: examples/alpine/service #Do not change
 ```
+The service dir above is only applicable to the RPMs which needs containerz workflow support.
+Life cycle of third-party application having service file will be managed via containerz workflow only.
+Users will not be able to perform app manager config post rpm installation on such applications.
+To include service-dir file structure in the rpm being built, an option "--containerz" has to be passed
+in the build command below explicitly.
+
 Build:
 `./appmgr_build -b examples/alpine/build.yaml`
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ appmgr package uninstall package alpine-0.1.0-eXR_7.3.1.x86_64
 
 # Building an RPM to be installed using XR install cli workflow
 (Scriplets are not supported using this install method)
+
 Create a `build.yaml` file and add entries for your app
 ```
 - name: "partner-alpine" # Prefix "owner-" or "partner-" for TPA apps (Prefix not editable)
@@ -169,7 +170,7 @@ We can optionally pass comma separated package name(s) in build command with -p 
 If we don't pass -p option, it will build for all the packages in build.yaml file.
 ```
 
-# Building a owner-process-script RPM to be installed using XR cli workflow
+# Building an owner-process-script RPM to be installed using XR cli workflow
 Create a `build.yaml` file and add entries for your app
 ```
 - name: "owner-pscript" #This should not be changed (Not editable)

--- a/appmgr_build
+++ b/appmgr_build
@@ -41,6 +41,9 @@ def pkg_config_dir(package, *args):
 def pkg_data_dir(package, *args):
     return archive_dir(package, "data", *args)
 
+def pkg_service_dir(package, *args):
+    return archive_dir(package, "service", *args)
+
 def key_dir(*args):
     return archive_dir("keys", *args)
 
@@ -67,6 +70,9 @@ group = parser.add_mutually_exclusive_group(required=True)
 
 parser.add_argument(
     "-p", "--package_names", type=list_of_strings, help="Package name to be built"
+)
+parser.add_argument(
+    '--containerz', dest="containerz", default=False, help="option for containerz", action="store_true"
 )
 group.add_argument(
     "-b", "--build-config", dest="config", help="build configuration"
@@ -201,6 +207,35 @@ def make_owner_rpm_spec(package, pre, post, preun, install, files):
             for name in subfiles:
                 files.append("{}".format(normjoin(data_dest, root, name)))
 
+    install.append("")
+    install.append("# Service directory")
+    service_list = package.get("service-dir")
+    if args.containerz and service_list:
+        service_name = service_list[0]["name"]
+        # Destination directory
+        service_dest = os.path.join(
+            release_conf["paths"]["appmgr_source"], "owner",
+            service_name, "service"
+        )
+        # Directory to copy
+        service_dir = os.path.join("service", service_name)
+        pre.append("rm -rf $RPM_INSTALL_PREFIX{}".format(service_dest))
+        install.append("mkdir -p %{{buildroot}}{}".format(service_dest))
+        files.append("%dir {}".format(service_dest))
+        install.append(
+            "cp -arT {} %{{buildroot}}{}".format(service_dir, service_dest)
+        )
+
+        prefix = pkg_service_dir(package_name, service_name)
+        for root, subdirs, subfiles in os.walk(prefix):
+            # Make path relative to pkg_service_dir
+            root = os.path.relpath(root, start=prefix)
+            for name in subdirs:
+                files.append("%dir {}".format(normjoin(service_dest, root, name)))
+            for name in subfiles:
+                files.append("{}".format(normjoin(service_dest, root, name)))
+
+
 def make_partner_rpm_spec(package, pre, post, preun, install, files):
     install.append("# Sources")
     source_dest = os.path.join(release_conf["paths"]["appmgr_source"], "partner", package["partner-name"])
@@ -280,7 +315,7 @@ def make_partner_rpm_spec(package, pre, post, preun, install, files):
         data_name = data_list[0]["name"]
         # Destination directory
         data_dest = os.path.join(
-            release_conf["paths"]["appmgr_source"], "partner",
+            release_conf["paths"]["appmgr_source"], "partner", package["partner-name"],
             data_name, "data"
         )
         # Directory to copy
@@ -299,6 +334,36 @@ def make_partner_rpm_spec(package, pre, post, preun, install, files):
                 files.append("%dir {}".format(normjoin(data_dest, root, name)))
             for name in subfiles:
                 files.append("{}".format(normjoin(data_dest, root, name)))
+
+    install.append("")
+    install.append("# Service directory")
+    service_list = package.get("service-dir")
+    if args.containerz and service_list:
+        service_name = service_list[0]["name"]
+        # Destination directory
+        service_dest = os.path.join(
+            release_conf["paths"]["appmgr_source"], "partner", package["partner-name"],
+            service_name, "service"
+        )
+        # Directory to copy
+        service_dir = os.path.join("service", service_name)
+        pre.append("rm -rf $RPM_INSTALL_PREFIX{}".format(service_dest))
+        install.append("mkdir -p %{{buildroot}}{}".format(service_dest))
+        files.append("%dir {}".format(service_dest))
+        install.append(
+            "cp -arT {} %{{buildroot}}{}".format(service_dir, service_dest)
+        )
+
+        prefix = pkg_service_dir(package_name, service_name)
+        for root, subdirs, subfiles in os.walk(prefix):
+            # Make path relative to pkg_service_dir
+            root = os.path.relpath(root, start=prefix)
+            for name in subdirs:
+                files.append("%dir {}".format(normjoin(service_dest, root, name)))
+            for name in subfiles:
+                files.append("{}".format(normjoin(service_dest, root, name)))
+
+
 
 def make_native_rpm_spec(package, pre, post, preun, install, files):
     install.append("# Sources")
@@ -595,6 +660,16 @@ def add_partner_rpm_files(package, package_name):
         dest = pkg_data_dir(package_name, data_name)
         shutil.copytree(data_list[0]["dir"], dest)
 
+    print("Adding service...")
+    os.makedirs(pkg_service_dir(package_name), exist_ok=False)
+    print(" --->", package["name"])
+    service_list = package.get("service-dir")
+    if args.containerz and service_list:
+        service_name = service_list[0]["name"]
+        print(" --->", service_name)
+        dest = pkg_service_dir(package_name, service_name)
+        shutil.copytree(service_list[0]["dir"], dest)
+
 def add_owner_rpm_files(package, package_name):
     rpm_type = package["name"]
     release_conf.read(
@@ -643,6 +718,17 @@ def add_owner_rpm_files(package, package_name):
         print(" --->", data_name)
         dest = pkg_data_dir(package_name, data_name)
         shutil.copytree(data_list[0]["dir"], dest)
+
+    print("Adding service...")
+    os.makedirs(pkg_service_dir(package_name), exist_ok=False)
+    print(" --->", package["name"])
+    service_list = package.get("service-dir")
+    if args.containerz and service_list:
+        service_name = service_list[0]["name"]
+        print(" --->", service_name)
+        dest = pkg_service_dir(package_name, service_name)
+        shutil.copytree(service_list[0]["dir"], dest)
+
 
 def add_native_rpm_files(package, package_name):
     rpm_type = package["release"]

--- a/examples/alpine/build.yaml
+++ b/examples/alpine/build.yaml
@@ -43,6 +43,9 @@ packages:
   data-dir:
     - name: alpine
       dir: examples/alpine/data #Do not change
+  service-dir:
+    - name: alpine
+      dir: examples/alpine/service #Do not change
   copy_hostname: true
   copy_ems_cert: true
 
@@ -60,6 +63,9 @@ packages:
   data-dir:
     - name: alpine
       dir: examples/alpine/data #Do not change
+  service-dir:
+    - name: alpine
+      dir: examples/alpine/service #Do not change
   copy_hostname: true
   copy_ems_cert: true
 

--- a/examples/alpine/service/alpine.yaml
+++ b/examples/alpine/service/alpine.yaml
@@ -1,0 +1,5 @@
+application: alp-logger-cntz
+type: docker
+source: alpine
+run-opts: --net=host -it
+run-cmd: sh


### PR DESCRIPTION
TPA RPM (With service file)
The service file is only applicable to the RPMs which needs containerz workflow support.
Life cycle of third-party application having service file will be managed via containerz workflow only. 
Users will not be able to perform app manager config post rpm installation on such applications.

In part of containerz feature, we need to have owner/partner rpm with service file. Below is the content and internal file structure of service file.

rpm -qpl owner-bonnet-4.0-25.1.1.x86_64.rpm 
/opt/owner/bonnet 
/opt/owner/bonnet/bonnet.tar.gz 
/opt/owner/bonnet/service/bonnet.yaml

Sample service file- (bonnet.yaml) 
application: bnt-logger-cntz 
type: docker 
source: bonnet 
run-opts: --net=host -it 
run-cmd: sh