### PR TITLE
CSCwq46684

### DIFF
--- a/appmgr_build
+++ b/appmgr_build
@@ -130,7 +130,7 @@ def make_owner_rpm_spec(package, pre, post, preun, install, files):
             )
         )
         install.append(
-            "cp -ar {} %{{buildroot}}{}".format(
+            "cp -r --no-preserve=ownership {} %{{buildroot}}{}".format(
                 os.path.join("sources", source_name), source_dest
             )
         )
@@ -150,7 +150,7 @@ def make_owner_rpm_spec(package, pre, post, preun, install, files):
         install.append("mkdir -p %{{buildroot}}{}".format(conf_dest))
         files.append("%dir {}".format(conf_dest))
         install.append(
-            "cp -arT {} %{{buildroot}}{}".format(conf_dir, conf_dest)
+            "cp -rT --no-preserve=ownership {} %{{buildroot}}{}".format(conf_dir, conf_dest)
         )
 
         prefix = pkg_config_dir(package_name, config_name)
@@ -200,7 +200,7 @@ def make_owner_rpm_spec(package, pre, post, preun, install, files):
         install.append("mkdir -p %{{buildroot}}{}".format(data_dest))
         files.append("%dir {}".format(data_dest))
         install.append(
-            "cp -arT {} %{{buildroot}}{}".format(data_dir, data_dest)
+            "cp -rT --no-preserve=ownership {} %{{buildroot}}{}".format(data_dir, data_dest)
         )
 
         prefix = pkg_data_dir(package_name, data_name)
@@ -228,7 +228,7 @@ def make_owner_rpm_spec(package, pre, post, preun, install, files):
         install.append("mkdir -p %{{buildroot}}{}".format(service_dest))
         files.append("%dir {}".format(service_dest))
         install.append(
-            "cp -arT {} %{{buildroot}}{}".format(service_dir, service_dest)
+            "cp -rT --no-preserve=ownership {} %{{buildroot}}{}".format(service_dir, service_dest)
         )
 
         prefix = pkg_service_dir(package_name, service_name)
@@ -259,7 +259,7 @@ def make_partner_rpm_spec(package, pre, post, preun, install, files):
             )
         )
         install.append(
-            "cp -ar {} %{{buildroot}}{}".format(
+            "cp -r --no-preserve=ownership {} %{{buildroot}}{}".format(
                 os.path.join("sources", source_name), source_dest
             )
         )
@@ -279,7 +279,7 @@ def make_partner_rpm_spec(package, pre, post, preun, install, files):
         install.append("mkdir -p %{{buildroot}}{}".format(conf_dest))
         files.append("%dir {}".format(conf_dest))
         install.append(
-            "cp -arT {} %{{buildroot}}{}".format(conf_dir, conf_dest)
+            "cp -rT --no-preserve=ownership {} %{{buildroot}}{}".format(conf_dir, conf_dest)
         )
 
         prefix = pkg_config_dir(package_name, config_name)
@@ -329,7 +329,7 @@ def make_partner_rpm_spec(package, pre, post, preun, install, files):
         install.append("mkdir -p %{{buildroot}}{}".format(data_dest))
         files.append("%dir {}".format(data_dest))
         install.append(
-            "cp -arT {} %{{buildroot}}{}".format(data_dir, data_dest)
+            "cp -rT --no-preserve=ownership {} %{{buildroot}}{}".format(data_dir, data_dest)
         )
         prefix = pkg_data_dir(package_name, data_name)
         for root, subdirs, subfiles in os.walk(prefix):
@@ -356,7 +356,7 @@ def make_partner_rpm_spec(package, pre, post, preun, install, files):
         install.append("mkdir -p %{{buildroot}}{}".format(service_dest))
         files.append("%dir {}".format(service_dest))
         install.append(
-            "cp -arT {} %{{buildroot}}{}".format(service_dir, service_dest)
+            "cp -rT --no-preserve=ownership {} %{{buildroot}}{}".format(service_dir, service_dest)
         )
 
         prefix = pkg_service_dir(package_name, service_name)
@@ -386,7 +386,7 @@ def make_native_rpm_spec(package, pre, post, preun, install, files):
             )
         )
         install.append(
-            "cp -ar {} %{{buildroot}}{}".format(
+            "cp -r --no-preserve=ownership {} %{{buildroot}}{}".format(
                 os.path.join("sources", source_name), source_dest
             )
         )
@@ -408,7 +408,7 @@ def make_native_rpm_spec(package, pre, post, preun, install, files):
         install.append("mkdir -p %{{buildroot}}{}".format(conf_dest))
         files.append("%dir {}".format(conf_dest))
         install.append(
-            "cp -arT {} %{{buildroot}}{}".format(conf_dir, conf_dest)
+            "cp -rT --no-preserve=ownership {} %{{buildroot}}{}".format(conf_dir, conf_dest)
         )
 
         prefix = pkg_config_dir(package_name, config_name)
@@ -458,7 +458,7 @@ def make_native_rpm_spec(package, pre, post, preun, install, files):
         install.append("mkdir -p %{{buildroot}}{}".format(data_dest))
         files.append("%dir {}".format(data_dest))
         install.append(
-            "cp -arT {} %{{buildroot}}{}".format(data_dir, data_dest)
+            "cp -rT --no-preserve=ownership {} %{{buildroot}}{}".format(data_dir, data_dest)
         )
 
         prefix = pkg_data_dir(package_name, data_name)
@@ -483,7 +483,7 @@ def make_pscript_rpm_spec(package, pre, post, preun, install, files):
             "%dir {}".format(os.path.join(source_dest, source_name))
         )
         install.append(
-            "cp -ar {} %{{buildroot}}{}".format(
+            "cp -r --no-preserve=ownership {} %{{buildroot}}{}".format(
                 os.path.join("sources", source_name), source_dest
             )
         )
@@ -507,7 +507,7 @@ def make_ownerpscript_rpm_spec(package, pre, post, preun, install, files):
             "%dir {}".format(os.path.join(source_dest, source_name))
         )
         install.append(
-            "cp -ar {} %{{buildroot}}{}".format(
+            "cp -r --no-preserve=ownership {} %{{buildroot}}{}".format(
                 os.path.join("sources", source_name), source_dest
             )
         )
@@ -531,7 +531,7 @@ def make_ownersandbox_rpm_spec(package, pre, post, preun, install, files):
             "%dir {}".format(os.path.join(source_dest, source_name))
         )
         install.append(
-            "cp -ar {} %{{buildroot}}{}".format(
+            "cp -r --no-preserve=ownership {} %{{buildroot}}{}".format(
                 os.path.join("sources", source_name), source_dest
             )
         )


### PR DESCRIPTION
Problem -
xr-sw-appmgr build tool not working on /ws/ or /auto/ path, works only from /nobackup/

Root cause - 
The reason build tool were failing for /ws or /auto path was that, while building there is a command that executes, which cause  failure,

cp -ar sources/ubuntu /usr/lib64/rpm/../../../var/tmp/owner-ubuntu-root/opt/owner
cp: failed to preserve ownership for '/usr/lib64/rpm/../../../var/tmp/owner-ubuntu-root/opt/owner/ubuntu/ubuntu.tar.gz':Operation not permitted
cp: failed to preserve ownership for '/usr/lib64/rpm/../../../var/tmp/owner-ubuntu-root/opt/owner/ubuntu': Operation not permitted
error: Bad exit status from /var/tmp/rpm-tmp.30806 (%install)

This failure is seen because cp -a (or -ar) tries to preserve ownership, permissions, and timestamps, but we're copying files to a location where preserving ownership is restricted — usually because we're not root inside a fakeroot-like environment, or because we're copying across file systems or to a destination that doesn't allow chown.

This specific case likely happens during RPM package building (due to /usr/lib64/rpm/…/var/tmp/ paths), and we’re trying to stage files into a buildroot that mimics the final filesystem layout.


Code change-

I have add "--no-preserve=ownership" in cp command, which tells to not preserve ownership, as that is managed by defattr already. When building an RPM, preserving ownership during the copy step inside buildroot is generally not necessary and can even cause permission errors (like the one we saw)

So 
cp -ar sources/ubuntu /usr/lib64/rpm/../../../var/tmp/owner-ubuntu-root/opt/owner
changes to
cp -r  --no-preserve=ownership sources/ubuntu /usr/lib64/rpm/../../../var/tmp/owner-ubuntu-root/opt/owner