### PR TITLE
This change is to change partner pscript RPM file structure

### DIFF
--- a/appmgr_build
+++ b/appmgr_build
@@ -519,7 +519,7 @@ def make_ownerpscript_rpm_spec(package, pre, post, preun, install, files):
 
 def make_partnerpscript_rpm_spec(package, pre, post, preun, install, files):
     install.append("# Sources")
-    source_dest = os.path.join(release_conf["paths"]["appmgr_source"], package["partner-name"], "ops-script-repo", "exec")
+    source_dest = os.path.join(release_conf["paths"]["appmgr_source"], "ops-script-repo", "exec", package["partner-name"])
     source_list = package.get("sources")
     if source_list:
         source_name = source_list[0]["name"]


### PR DESCRIPTION
The current partner pscript rpm is,

opt/partner/<partner-name>/ops-script-repo/exec

As above is a dynamic path in context of ops-pscript-repo, The ask from script-mgmt team is to have below path for partner pscript RPM,

/opt/partner/ops-script-repo/exec/<partner-name>

Below is the change post the changes,

rpm -qpl /auto/tftp-blr-users1/nburnwal/Appmgr/partner-pscript-0.1.0-7.3.6.x86_64.rpm
 warning: /auto/tftp-blr-users1/nburnwal/Appmgr/partner-pscript-0.1.0-7.3.6.x86_64.rpm: Header V4 RSA/SHA256 Signature, key ID 5c06976b: NOKEY
 /opt/partner/ops-script-repo/exec/radware
 /opt/partner/ops-script-repo/exec/radware/pscript
 /opt/partner/ops-script-repo/exec/radware/pscript/.gitignore
 /opt/partner/ops-script-repo/exec/radware/pscript/test
 
