### PR TITLE
Adding support to pass target platform as an option during rpm build

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,19 +173,6 @@ Relocations : /
 Packager    : cisco
 Summary     : pscript 0.1.0 compiled for IOS-XR 24.1.1
 ```
-Optionally pass comma separated package name(s) in build command with -p option
-```
-./appmgr_build -b examples/alpine/build.yaml -p alpine,pscript
-
-If -p option is not passed, the build will process all packages in build.yaml file.
-```
-
-Optionally pass target platform name in build command with -t option
-```
-./appmgr_build -b examples/alpine/build.yaml -t aarch64
-
-If -t option is not passed, rpms will be built for x86_64 platform.
-```
 
 # Building an owner-process-script RPM to be installed using XR cli workflow
 Create a `build.yaml` file and add entries for the app
@@ -381,8 +368,23 @@ Description :
 RPM built for use with IOS-XR appmgr.
 
 XR-appmgr-build version: 46055cab7d8ceff6fd1c3444195761574ac2e146
+```
 
 # Build and Setup instructions
+
+Optionally pass comma separated package name(s) in build command with -p option
+```
+./appmgr_build -b examples/alpine/build.yaml -p alpine,pscript
+
+If -p option is not passed, the build will process all packages in build.yaml file.
+```
+
+Optionally pass target architecture name in build command with -t option
+```
+./appmgr_build -b examples/alpine/build.yaml -t aarch64
+
+If -t option is not passed, rpms will be built for x86_64 architecture.
+```
 
 ## Setting up the build environment
 The RPM build takes place inside a docker container. The image for the container is defined in the corresponding release config file. The corresponding docker image is built as a part of each RPM build.

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Optionally pass comma separated package name(s) in build command with -p option
 If -p option is not passed, the build will process all packages in build.yaml file.
 ```
 
-Optionally pass target platform name(s) in build command with -t option
+Optionally pass target platform name in build command with -t option
 ```
 ./appmgr_build -b examples/alpine/build.yaml -t aarch64
 

--- a/README.md
+++ b/README.md
@@ -180,6 +180,13 @@ Optionally pass comma separated package name(s) in build command with -p option
 If -p option is not passed, the build will process all packages in build.yaml file.
 ```
 
+Optionally pass target platform name(s) in build command with -t option
+```
+./appmgr_build -b examples/alpine/build.yaml -t aarch64
+
+If -t option is not passed, rpms will be built for x86_64 platform.
+```
+
 # Building an owner-process-script RPM to be installed using XR cli workflow
 Create a `build.yaml` file and add entries for the app
 ```

--- a/appmgr_build
+++ b/appmgr_build
@@ -69,7 +69,7 @@ group = parser.add_mutually_exclusive_group(required=True)
 
 
 parser.add_argument(
-    '-t', "--aarch",  type=str, help="option for architectures (e.g x86_64, aarch64"
+    '-t', "--target",  type=str, help="option for target architecture (e.g x86_64, aarch64"
 )
 
 parser.add_argument(
@@ -1040,8 +1040,8 @@ for package in config["packages"]:
 
     spec_file = os.path.join(release_conf["build"]["rpm_spec_dir"], spec_name)
     target = "x86_64"
-    if args.aarch:
-        target = args.aarch
+    if args.target:
+        target = args.target
 
     command = [
         "/usr/sbin/build_rpm.sh",

--- a/appmgr_build
+++ b/appmgr_build
@@ -69,7 +69,7 @@ group = parser.add_mutually_exclusive_group(required=True)
 
 
 parser.add_argument(
-    '-t', "--platform",  type=str, help="option for platforms (e.g x86_64, aarch64"
+    '-t', "--aarch",  type=str, help="option for architectures (e.g x86_64, aarch64"
 )
 
 parser.add_argument(
@@ -1040,8 +1040,8 @@ for package in config["packages"]:
 
     spec_file = os.path.join(release_conf["build"]["rpm_spec_dir"], spec_name)
     target = "x86_64"
-    if args.platform:
-        target = args.platform
+    if args.aarch:
+        target = args.aarch
 
     command = [
         "/usr/sbin/build_rpm.sh",

--- a/appmgr_build
+++ b/appmgr_build
@@ -69,8 +69,13 @@ group = parser.add_mutually_exclusive_group(required=True)
 
 
 parser.add_argument(
+    '-t', "--platform",  type=str, help="option for platforms (e.g x86_64, aarch64"
+)
+
+parser.add_argument(
     "-p", "--package_names", type=list_of_strings, help="Package name to be built"
 )
+
 parser.add_argument(
     '--containerz', dest="containerz", default=False, help="option for containerz", action="store_true"
 )
@@ -1034,8 +1039,14 @@ for package in config["packages"]:
         f.write(spec)
 
     spec_file = os.path.join(release_conf["build"]["rpm_spec_dir"], spec_name)
+    target = "x86_64"
+    if args.platform:
+        target = args.platform
+
     command = [
         "/usr/sbin/build_rpm.sh",
+        "--target",
+        target,
         "--spec-file",
         spec_file,
         "--source-dir",

--- a/docker/build_rpm.sh
+++ b/docker/build_rpm.sh
@@ -18,6 +18,7 @@ while true; do
   case "$1" in
     -v | --verbose )         VERBOSE=true; shift ;;
     -h | --help )            echo "$usage"; exit 0 ;;
+    -t | --target )          target=$2;shift; shift;;
     -s | --spec-file )       spec_file=$2;shift; shift;; 
     -k | --gpg-key )         gpg_key=$2;shift; shift;;
     -r | --source-dir )      source_dir=$2;shift; shift;;
@@ -74,7 +75,7 @@ __EOF__
     echo "GPG key specified. Attempting to import key"
 fi
 
-/usr/bin/rpmbuild --verbose -bb ${spec_file} > ${log_file} 2>&1
+/usr/bin/rpmbuild --verbose --target=${target} -bb ${spec_file} > ${log_file} 2>&1
 rpm_build_ec=$?
 
 if [[ $rpm_build_ec -eq 0 ]]; then


### PR DESCRIPTION
Optionally pass target platform name(s) in build command with -t option

./appmgr_build -b examples/alpine/build.yaml -t aarch64

If -t option is not passed, rpms will be built for x86_64 platform.